### PR TITLE
fix: Correct text alignment for name box escape characters

### DIFF
--- a/RS_MessageAlign.js
+++ b/RS_MessageAlign.js
@@ -101,7 +101,7 @@ RS.MessageAlign = RS.MessageAlign || {};
     Game_Message.prototype.clear = function () {
         alias_Game_Message_clear.call(this);
         this._align = [];
-        this._alignLast = -1;
+        this._alignLast = undefined;  // Changed from -1
     };
 
     Game_Message.prototype.setAlign = function (n) {
@@ -110,12 +110,11 @@ RS.MessageAlign = RS.MessageAlign || {};
         this._align.push(n);
     };
 
-    Game_Message.prototype.getAlign = function (n) {
-        n = this._align.shift();
-        if (n === undefined) {
-            return this._alignLast;
+    Game_Message.prototype.getAlign = function() {
+        if (this._align.length > 0) {
+            return this._align[0]; // Peek at next alignment without shifting
         }
-        return n;
+        return this._alignLast; // Returns undefined when no alignment set
     };
 
     Game_Message.prototype.clearAlignLast = function () {
@@ -189,11 +188,16 @@ RS.MessageAlign = RS.MessageAlign || {};
         }
     };
 
-    Window_Base.prototype.processAlign = function (textState) {
+    Window_Base.prototype.processAlign = function(textState) {
         textState = textState || this._textState;
-        switch ($gameMessage.getAlign()) {
-            // eslint-disable-next-line default-case-last
-            default:
+        const alignment = $gameMessage.getAlign();
+        
+        // Only process valid alignments
+        if (typeof alignment !== 'number' || alignment < 0 || alignment > 2) {
+            return; // Preserve original alignment
+        }
+    
+        switch(alignment) {
             case 0:
                 this.setAlignLeft(textState);
                 break;
@@ -203,6 +207,11 @@ RS.MessageAlign = RS.MessageAlign || {};
             case 2:
                 this.setAlignRight(textState);
                 break;
+        }
+        
+        // Remove processed alignment
+        if ($gameMessage._align.length > 0) {
+            $gameMessage._align.shift();
         }
     };
 

--- a/RS_MessageAlign.js
+++ b/RS_MessageAlign.js
@@ -7,7 +7,7 @@
 // Free for commercial and non commercial use.
 //================================================================
 /*:
- * @plugindesc (v1.0.30) This plugin allows you to align the text in the message system.
+ * @plugindesc (v1.1.0) This plugin allows you to align the text in the message system.
  * @author biud436
  * @help
  * =============================================================================
@@ -81,6 +81,8 @@
  * - Fixed the issue that is not defined the variable called 'tx' after refactoring the code.
  * 2023.11.08 (v1.0.30) :
  * - Fixed a compatibility issue with the YEP_EventMiniLabel plugin.
+ * 2025.03.06 (v1.1.0) :
+ * - Fixed the default text alignment when using the name box text codes from YEP_ExtMesPack1 plugin.
  */
 
 // eslint-disable-next-line no-var


### PR DESCRIPTION
When using the name box escape character from YEP_ExtMesPack1 plugin (\n etc, etc), this plugin would force a left-centered alignment of the text (default) which is wrong because Yanfly's plugin actually uses a centered alignment when using the name box escape character.

Instead of returning a left alignment by default, it will return undefined which keeps the original text alignment.